### PR TITLE
Rename "Sleep Diary Library" to "Sleep Diary Core Library"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ These projects are being actively developed and already have a working implement
 | Project      | Description (short)                                    | Status       | Comments |
 |--------------|--------------------------------------------------------|--------------|----------|
 | [Sleep Diary Dashboard](https://sleepdiary.github.io/dashboard) | A dashboard to view your sleep diary | Active development | [Source code](https://github.com/sleepdiary/dashboard) |
-| [Sleep Diary Library](https://github.com/sleepdiary/library) | Documentation and code for manipulating sleep diaries | Active development | |
+| [Sleep Diary Core Library](https://github.com/sleepdiary/core) | Documentation and code for manipulating sleep diaries | Active development | |
 | [Sleep Diary Info](https://github.com/sleepdiary/info) | Analyse your sleep diary | Active development | |
 | [Sleep Diary Report](https://github.com/sleepdiary/report) | A report for use by sleep doctors | Active development | |
 | [SleepCharter](https://sleepcharter.z13.web.core.windows.net/) | Tool to generate sleep charts from CSV files of some popular devices / apps | Live | Source code not published, made by [Kizari](https://github.com/Kizari) |


### PR DESCRIPTION
Hey,

Thanks for adding these links.  We're still working out how it all works, and I've just changed the "library" repository to "core".  Could you update that link on the page please?